### PR TITLE
Add instructions on setting up a local development server

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ Before being a movie, Madagascar is above all a country, more specifically an is
 
 With a collective of CS students, we decided to start this project about discovering Madagascar through these interactive maps. 
 
+## Local development
+To install locally, setup a web server in order to serve the file:
+- python: `python3 -m http.server 8080`
+- Use the [httpd docker image](https://hub.docker.com/_/httpd): `docker run -dit --name my-apache-app -p 8080:80 -v "$PWD":/usr/local/apache2/htdocs/ httpd:2.4`
+- Use the [http-server](https://www.npmjs.com/package/http-server) npm package
+
+Additional method can be found [here](https://stackoverflow.com/a/21608670/19479836) (Stack Overflow).
+
 ## Contributing
 
 You can contribute by opening a ``pull request``. You can create your map in another ``.js`` and add it as an import in the ``index.html``. Do not forget to add a button for your map in the ``.header``.


### PR DESCRIPTION
This PR adds some instructions on setting up a local server for development or just to view the project locally, since there's no public link on the repo.

This also fix #1 
